### PR TITLE
Add support for loongarch64 architecture

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -44,6 +44,9 @@
   <PropertyGroup Condition="'$(BUILD_OS)' == 'Linux' AND '$(PackageRuntime)' == 'linux-arm64'">
     <DefineConstants>$(DefineConstants);ARM64</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(BUILD_OS)' == 'Linux' AND '$(PackageRuntime)' == 'linux-loongarch64'">
+    <DefineConstants>$(DefineConstants);LOONGARCH64</DefineConstants>
+  </PropertyGroup>
 
   <!-- Set TRACE/DEBUG vars -->
   <PropertyGroup>

--- a/src/Misc/dotnet-install.sh
+++ b/src/Misc/dotnet-install.sh
@@ -307,6 +307,10 @@ get_machine_architecture() {
             echo "arm64"
             return 0
             ;;
+        loongarch64)
+            echo "loongarch64"
+            return 0
+            ;;
         esac
     fi
 
@@ -336,6 +340,10 @@ get_normalized_architecture_from_architecture() {
             ;;
         arm64)
             echo "arm64"
+            return 0
+            ;;
+        loongarch64)
+            echo "loongarch64"
             return 0
             ;;
     esac
@@ -1129,7 +1137,7 @@ do
             echo "      -InstallDir"
             echo "  --architecture <ARCHITECTURE>      Architecture of dotnet binaries to be installed, Defaults to \`$architecture\`."
             echo "      --arch,-Architecture,-Arch"
-            echo "          Possible values: x64, arm, and arm64"
+            echo "          Possible values: x64, arm, arm64 and loongarch64"
             echo "  --os <system>                    Specifies operating system to be used when selecting the installer."
             echo "          Overrides the OS determination approach used by the script. Supported values: osx, linux, linux-musl, freebsd, rhel.6."
             echo "          In case any other value is provided, the platform will be determined by the script based on machine configuration."

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -10,6 +10,8 @@ NODE_ALPINE_URL=https://github.com/actions/alpine_nodejs/releases/download
 NODE16_VERSION="16.20.2"
 NODE20_VERSION="20.13.1"
 NODE16_UNOFFICIAL_VERSION="16.20.0" # used only for win-arm64, remove node16 unofficial version when official version is available
+NODE18_UNOFFICIAL_VERSION="18.20.4" # used only for linux-loongarch64
+NODE20_UNOFFICIAL_VERSION="20.13.1" # used only for linux-loongarch64
 
 get_abs_path() {
   # exploits the fact that pwd will print abs path when no args
@@ -189,4 +191,9 @@ fi
 if [[ "$PACKAGERUNTIME" == "linux-arm" ]]; then
     acquireExternalTool "$NODE_URL/v${NODE16_VERSION}/node-v${NODE16_VERSION}-linux-armv7l.tar.gz" node16 fix_nested_dir
     acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-armv7l.tar.gz" node20 fix_nested_dir
+fi
+
+if [[ "$PACKAGERUNTIME" == "linux-loongarch64" ]]; then
+    acquireExternalTool "$UNOFFICIAL_NODE_URL/v${NODE18_UNOFFICIAL_VERSION}/node-v${NODE18_UNOFFICIAL_VERSION}-linux-loong64.tar.gz" node18 fix_nested_dir
+    acquireExternalTool "$UNOFFICIAL_NODE_URL/v${NODE20_UNOFFICIAL_VERSION}/node-v${NODE20_UNOFFICIAL_VERSION}-linux-loong64.tar.gz" node20 fix_nested_dir
 fi

--- a/src/Runner.Common/Constants.cs
+++ b/src/Runner.Common/Constants.cs
@@ -58,7 +58,8 @@ namespace GitHub.Runner.Common
             X86,
             X64,
             Arm,
-            Arm64
+            Arm64,
+            LoongArch64
         }
 
         public static class Runner
@@ -81,6 +82,8 @@ namespace GitHub.Runner.Common
             public static readonly Architecture PlatformArchitecture = Architecture.Arm;
 #elif ARM64
             public static readonly Architecture PlatformArchitecture = Architecture.Arm64;
+#elif LOONGARCH64
+            public static readonly Architecture PlatformArchitecture = Architecture.LoongArch64;
 #else
             public static readonly Architecture PlatformArchitecture = Architecture.X64;
 #endif

--- a/src/Runner.Common/Runner.Common.csproj
+++ b/src/Runner.Common/Runner.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;linux-loongarch64;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603</NoWarn>
     <Version>$(Version)</Version>

--- a/src/Runner.Common/Util/VarUtil.cs
+++ b/src/Runner.Common/Util/VarUtil.cs
@@ -53,6 +53,8 @@ namespace GitHub.Runner.Common.Util
                         return "ARM";
                     case Constants.Architecture.Arm64:
                         return "ARM64";
+                    case Constants.Architecture.LoongArch64:
+                        return "LOONGARCH64";
                     default:
                         throw new NotSupportedException(); // Should never reach here.
                 }

--- a/src/Runner.Listener/Runner.Listener.csproj
+++ b/src/Runner.Listener/Runner.Listener.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;linux-loongarch64;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603</NoWarn>
     <Version>$(Version)</Version>

--- a/src/Runner.PluginHost/Runner.PluginHost.csproj
+++ b/src/Runner.PluginHost/Runner.PluginHost.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;linux-loongarch64;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603</NoWarn>
     <Version>$(Version)</Version>

--- a/src/Runner.Plugins/Runner.Plugins.csproj
+++ b/src/Runner.Plugins/Runner.Plugins.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;linux-loongarch64;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603</NoWarn>
     <Version>$(Version)</Version>

--- a/src/Runner.Sdk/Runner.Sdk.csproj
+++ b/src/Runner.Sdk/Runner.Sdk.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;linux-loongarch64;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603</NoWarn>
     <Version>$(Version)</Version>

--- a/src/Runner.Worker/Runner.Worker.csproj
+++ b/src/Runner.Worker/Runner.Worker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;linux-loongarch64;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <NoWarn>NU1701;NU1603</NoWarn>
     <Version>$(Version)</Version>

--- a/src/Sdk/Sdk.csproj
+++ b/src/Sdk/Sdk.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <OutputType>Library</OutputType>
-        <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+        <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm64;linux-arm;linux-loongarch64;osx-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
         <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
         <NoWarn>NU1701;NU1603</NoWarn>
         <Version>$(Version)</Version>

--- a/src/Test/L0/ConstantGenerationL0.cs
+++ b/src/Test/L0/ConstantGenerationL0.cs
@@ -20,6 +20,7 @@ namespace GitHub.Runner.Common.Tests
                 "linux-x64",
                 "linux-arm",
                 "linux-arm64",
+                "linux-loongarch64",
                 "osx-x64",
                 "osx-arm64"
             };

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -56,6 +56,7 @@ elif [[ "$CURRENT_PLATFORM" == 'linux' ]]; then
         case $CPU_NAME in
             armv7l) RUNTIME_ID="linux-arm";;
             aarch64) RUNTIME_ID="linux-arm64";;
+            loongarch64) RUNTIME_ID="linux-loongarch64";;
         esac
     fi
 elif [[ "$CURRENT_PLATFORM" == 'darwin' ]]; then
@@ -74,7 +75,7 @@ fi
 
 # Make sure current platform support publish the dotnet runtime
 # Windows can publish win-x86/x64/arm64
-# Linux can publish linux-x64/arm/arm64
+# Linux can publish linux-x64/arm/arm64/loongarch64
 # OSX can publish osx-x64/arm64
 if [[ "$CURRENT_PLATFORM" == 'windows' ]]; then
     if [[ ("$RUNTIME_ID" != 'win-x86') && ("$RUNTIME_ID" != 'win-x64') && ("$RUNTIME_ID" != 'win-arm64') ]]; then
@@ -82,7 +83,7 @@ if [[ "$CURRENT_PLATFORM" == 'windows' ]]; then
         exit 1
     fi
 elif [[ "$CURRENT_PLATFORM" == 'linux' ]]; then
-    if [[ ("$RUNTIME_ID" != 'linux-x64') && ("$RUNTIME_ID" != 'linux-x86') && ("$RUNTIME_ID" != 'linux-arm64') && ("$RUNTIME_ID" != 'linux-arm') ]]; then
+    if [[ ("$RUNTIME_ID" != 'linux-x64') && ("$RUNTIME_ID" != 'linux-x86') && ("$RUNTIME_ID" != 'linux-arm64') && ("$RUNTIME_ID" != 'linux-arm') && ("$RUNTIME_ID" != 'linux-loongarch64') ]]; then
        echo "Failed: Can't build $RUNTIME_ID package $CURRENT_PLATFORM" >&2
        exit 1
     fi


### PR DESCRIPTION
* Add loongarch64 platform in Directory.Build.props and scripts.

* Add linux-loongarch64 RIDs to csproj files.

* Add constant LoongArch64 to architecture list in csharp files.

@shushanhf

This PR is from https://github.com/actions/runner/pull/2778 .